### PR TITLE
fix: time yolo26 as CUDA-graph replay, like every other TRT benchmark

### DIFF
--- a/sab/models/benchmark_yolo26.py
+++ b/sab/models/benchmark_yolo26.py
@@ -30,7 +30,7 @@ class YOLO26ONNXInference(ONNXInferenceCUDA):
 
 class YOLO26TRTInference(TRTInference):
     def __init__(self, model_path, image_input_name=None):
-        super().__init__(model_path, image_input_name, use_cuda_graph=False)
+        super().__init__(model_path, image_input_name, use_cuda_graph=True)
 
     def preprocess(self, input_image):
         return preprocess_image(input_image, self.image_input_shape)


### PR DESCRIPTION
## What does this PR do?

Changes the `YOLO26TRTInference` default from `use_cuda_graph=False` to `use_cuda_graph=True`, so yolo26 engines are timed as CUDA-graph replay like every other TRT benchmark class. The `False` value was a mistake in a633d50: with it, SAB cannot reproduce the published yolo26 benchmark numbers.

**Related Issue(s):** _n/a_

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**

Measured on a T4 (clocks locked at 1590 MHz with persistence mode, TRT 10.12.0.36, FP16 engine built by `sab.trt_inference.build_engine` from the public `yolo26n.onnx` artifact, 100 samples over COCO val2017, 0.2 s buffer, SAB's own CUDA-event timings with the capture call excluded from the median):

| model | use_cuda_graph | SAB median (ms) | [published (ms)](https://github.com/roboflow/rf-detr/blob/develop/README.md#benchmarks) |
|---|---|---|---|
| yolo26n | True (this PR) | 1.79 | 1.70 |
| yolo26n | False (current) | 1.97 - 2.04 | 1.70 |
| rfdetr-nano | True (unchanged) | 2.37 | 2.30 |

Graph-off timing misses the published yolo26n value by 16-20%. Graph-on timing lands within run noise of it, the same agreement the rfdetr classes (graph-on since inception) show against their README. The graph-off range across two runs (1.97 vs 2.04 for the same engine) also shows that standard execution with async CUDA-event timing is sensitive to same-stream work around the call; graph replay isolates the engine.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

The docstring in `benchmark_yolo26.py` already says preprocessing and postprocessing are identical to YOLOv11, and `YOLOv11TRTInference` uses the graph path. This change removes the one outlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)